### PR TITLE
:bug: ensure /root/.ssh directory exists

### DIFF
--- a/tasks/swift-hosts.yml
+++ b/tasks/swift-hosts.yml
@@ -1,6 +1,18 @@
 ---
 - name: Prepare Swift hosts
   block:
+    - name: Ensure root .ssh dir exists
+      file:
+        path: /root/.ssh
+        state: directory
+        owner: root
+        group: root
+        mode: 0700
+      when:
+        - 'inventory_hostname == "swift-admin"'
+      register: res_swift_sshdir
+      become: true
+
     - name: Generate SSH admin key
       openssh_keypair:
         path: /root/.ssh/id_rsa


### PR DESCRIPTION
Creating the SSH key for the root user on the swift-admin box fails when
the /root/.ssh directory does not exist.

This patch ensures the directory exists and has the right permissions.

Fixes #1