### PR TITLE
:bug: remove literal strings around disk label

### DIFF
--- a/tasks/swift-disk-prepare.yml
+++ b/tasks/swift-disk-prepare.yml
@@ -53,7 +53,7 @@
         fstype: xfs
         force: false
         dev: "/dev/{{ item.split()[1] }}"
-        opts: "-d sunit=512,swidth=512 -L '{{ item.split()[1] }}'"
+        opts: "-d sunit=512,swidth=512 -L {{ item.split()[1] }}"
       become: true
       with_items: "{{ swift_disks_list }}"
       when:


### PR DESCRIPTION
The literal string around the disk label is being encoded and included
in the label. This causes the Ansible playbook to not match the label
with the disk.

The literal string is not required as it is controlled, so remove it.