### PR TITLE
use swift_admin group instead of swift-admin host

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Requirements
 
 An inventory of pre-existing CentOS 8 Stream nodes with their networking configured.
 The cluster requires an admin box (included in `swift_admin` group) from which all the Swift nodes are managed.
+This can be one of your Swift nodes, if you don't have a separate admin host.
 
 If building a virtual Swift cluster, consider using `csmart.virt_infra` Ansible role at https://github.com/csmart/ansible-role-virt-infra.
 

--- a/tasks/swift-disk-prepare.yml
+++ b/tasks/swift-disk-prepare.yml
@@ -4,13 +4,13 @@
     - name: Match disk on node to Swift ID
       shell:
         cmd: swift-ring-builder /etc/swift/{{ item }}.builder search --region 1 --zone 1 --ip {{ swift_cluster_ip }} |grep -v Devices | awk '{print $1,$8}'
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       register: res_swift_devices
       changed_when: false
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
       with_items:
         - account
         - container
@@ -21,7 +21,7 @@
         swift_disks_list: "{{ (swift_disks_list | default([]) + item.stdout_lines) |unique }}"
         cacheable: yes
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
       with_items: "{{ res_swift_devices.results }}"
 
     - name: Ensure directory exists for disks
@@ -33,7 +33,7 @@
         mode: 0770
       become: true
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
     - name: Ensure directory exists for each disk
       file:
@@ -45,7 +45,7 @@
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
     # format the disk if not already formatted
     - name: Format disks
@@ -57,7 +57,7 @@
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
     # mount the disk
     - name: Mount the drives
@@ -70,7 +70,7 @@
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
     - name: Ensure permissions on each disk mount
       file:
@@ -82,7 +82,7 @@
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
     # if fail, do we take it out of the ring?
     # you can push the ring and rebalance

--- a/tasks/swift-hosts.yml
+++ b/tasks/swift-hosts.yml
@@ -9,7 +9,7 @@
         group: root
         mode: 0700
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       register: res_swift_sshdir
       become: true
 
@@ -20,7 +20,7 @@
         size: 2048
         state: present
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       register: res_swift_sshkeygen
       become: true
 
@@ -28,7 +28,7 @@
       set_fact:
         swift_admin_ssh_public_key: "{{ res_swift_sshkeygen.public_key }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       run_once: true
 
     - name: Copy SSH admin public key to nodes
@@ -44,13 +44,13 @@
         host: "{{ swift_cluster_ip }}"
         search_regex: OpenSSH
         timeout: 600
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
 
     - name: Get node SSH fingerprints
       shell: "set -o pipefail && ssh-keyscan {{ inventory_hostname }} {{ swift_cluster_ip }} | sort"
       args:
         executable: /bin/bash
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       register: result_keyscan
       changed_when: false
 
@@ -65,7 +65,7 @@
           {{ hostvars[item]['result_keyscan']['stdout'] }}
       become: true
       changed_when: false
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       with_items: "{{ play_hosts }}"
       run_once: true
 
@@ -77,7 +77,7 @@
         block: |-
           {{ hostvars[item]['swift_cluster_ip'] }} {{ hostvars[item]['inventory_hostname'] }}
       become: true
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       with_items: "{{ play_hosts }}"
       run_once: true
 
@@ -93,7 +93,7 @@
             Hostname  {{ hostvars[item]['swift_cluster_ip'] }}
             IdentityFile /root/.ssh/id_rsa
       become: true
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       with_items: "{{ play_hosts }}"
       run_once: true
   tags:

--- a/tasks/swift-ring-builder.yml
+++ b/tasks/swift-ring-builder.yml
@@ -6,11 +6,11 @@
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder create {{ item.part_power }} {{ item.replicas }} {{ item.min_part_hours |default(1) }}
         creates: /etc/swift/{{ item.name }}.builder
       loop: "{{ swift_account_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
 
     - name: Create container ring
@@ -18,11 +18,11 @@
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder create {{ item.part_power }} {{ item.replicas }} {{ item.min_part_hours }}
         creates: /etc/swift/{{ item.name }}.builder
       loop: "{{ swift_container_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
 
     - name: Create object rings
@@ -32,11 +32,11 @@
       loop: "{{ swift_object_rings }}"
       loop_control:
         index_var: loop_index
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
 
     ## TODO update to put devices in the right rings
@@ -62,9 +62,9 @@
       with_subelements:
         - "{{ swift_rings_disks }}"
         - disk.rings
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
       become: true
       become_user: "{{ swift_user }}"
       ignore_errors: true

--- a/tasks/swift-ring-distribute.yml
+++ b/tasks/swift-ring-distribute.yml
@@ -6,10 +6,11 @@
         src: /etc/swift/{{ item.name }}.ring.gz
         dest: /etc/swift/{{ item.name }}.ring.gz
       loop: "{{ swift_account_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
+
       notify:
         - "restart openstack swift proxy server"
         - "restart openstack swift account server"
@@ -19,10 +20,10 @@
         src: /etc/swift/{{ item.name }}.ring.gz
         dest: /etc/swift/{{ item.name }}.ring.gz
       loop: "{{ swift_container_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
       notify:
         - "restart openstack swift proxy server"
         - "restart openstack swift container server"
@@ -34,10 +35,10 @@
       loop: "{{ swift_object_rings }}"
       loop_control:
         index_var: loop_index
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       when:
-        - 'inventory_hostname != "swift-admin"'
+        - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
       notify:
         - "restart openstack swift proxy server"
         - "restart openstack swift object server"

--- a/tasks/swift-ring-rebalance.yml
+++ b/tasks/swift-ring-rebalance.yml
@@ -5,11 +5,11 @@
       command:
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder rebalance {% if swift_rings_rebalance_force is defined and swift_rings_rebalance_force %} --force {% endif %}
       loop: "{{ swift_account_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
       register: result_rebalance_account
       failed_when: "'FAILED123' in result_rebalance_account.stderr"
@@ -18,11 +18,11 @@
       command:
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder rebalance {% if swift_rings_rebalance_force is defined and swift_rings_rebalance_force %} --force {% endif %}
       loop: "{{ swift_container_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
       register: result_rebalance_container
       failed_when: "'FAILED123' in result_rebalance_container.stderr"
@@ -33,11 +33,11 @@
       loop: "{{ swift_object_rings }}"
       loop_control:
         index_var: loop_index
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       ignore_errors: true
       register: result_rebalance_object
       failed_when: "'FAILED123' in result_rebalance_object.stderr"
@@ -46,11 +46,11 @@
       command:
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder validate
       loop: "{{ swift_account_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       register: res_swift_ring_validate
       ignore_errors: true
 
@@ -58,11 +58,11 @@
       command:
         cmd: swift-ring-builder /etc/swift/{{ item.name }}.builder validate
       loop: "{{ swift_container_rings }}"
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       register: res_swift_ring_validate
       ignore_errors: true
 
@@ -72,11 +72,11 @@
       loop: "{{ swift_object_rings }}"
       loop_control:
         index_var: loop_index
-      delegate_to: swift-admin
+      delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
       when:
-        - 'inventory_hostname == "swift-admin"'
+        - "inventory_hostname == groups['swift_admin'][0]"
       register: res_swift_ring_validate
       ignore_errors: true
   tags:


### PR DESCRIPTION
Originally the role expected a host called `swift-admin` this has been replaced with the first node in the `swift_admin` group instead.
    
This means if you don't have to have a machine called `swift-admin` in your inventory and you can also re-use one of the Swift nodes if you prefer.
