### PR TITLE
fix add ssh key task

### DIFF
--- a/tasks/swift-hosts.yml
+++ b/tasks/swift-hosts.yml
@@ -26,9 +26,7 @@
 
     - name: Set the public key
       set_fact:
-        swift_admin_ssh_public_key: "{{ res_swift_sshkeygen.public_key }}"
-      when:
-        - "inventory_hostname == groups['swift_admin'][0]"
+        swift_admin_ssh_public_key: "{{ hostvars[groups['swift_admin'][0]].res_swift_sshkeygen.public_key }}"
       run_once: true
 
     - name: Copy SSH admin public key to nodes


### PR DESCRIPTION
The SSH key task was set to run_once so that all nodes get it, but also
set to only run when the host was in the admin group.

The chosen host might not be in the admin group and therefore the task
is skipped, causing further steps to fail as they won't have the SSH
key.

This change instead lets it run_once but on any host and fetches the
variable directly from the first host in the admin group.