### PR TITLE
only run SELinux boolean task when not disabled

### DIFF
--- a/defaults/main/selinux.yml
+++ b/defaults/main/selinux.yml
@@ -1,0 +1,2 @@
+---
+swift_selinux_state: permissive

--- a/tasks/common-selinux.yml
+++ b/tasks/common-selinux.yml
@@ -15,7 +15,7 @@
 - name: Write SELinux config
   selinux:
     policy: targeted
-    state: "{{ swift_selinux_state | default('permissive') }}"
+    state: "{{ swift_selinux_state }}"
   become: true
   tags:
     - common
@@ -31,6 +31,7 @@
     - name: rsync_full_access
       state: yes
       persistent: yes
+  when: "swift_selinux_state != 'disabled'"
   tags:
     - common
     - selinux


### PR DESCRIPTION
The SELinux boolean task can can fail if SELinux is not in either
permissive or enforcing mode.

This patch skips the task if SELinux is set to disabled.