### PR TITLE
support more complex device paths

### DIFF
--- a/tasks/swift-disk-prepare.yml
+++ b/tasks/swift-disk-prepare.yml
@@ -3,7 +3,7 @@
   block:
     - name: Match disk on node to Swift ID
       shell:
-        cmd: swift-ring-builder /etc/swift/{{ item }}.builder search --region 1 --zone 1 --ip {{ swift_cluster_ip }} |grep -v Devices | awk '{print $1,$8}'
+        cmd: swift-ring-builder /etc/swift/{{ item }}.builder search --region 1 --zone 1 --ip {{ swift_cluster_ip }} |grep -v Devices | awk '{print $1,$8,$NF}'
       delegate_to: "{{ groups['swift_admin'][0] }}"
       become: true
       become_user: "{{ swift_user }}"
@@ -52,8 +52,8 @@
       filesystem:
         fstype: xfs
         force: false
-        dev: "/dev/{{ item.split()[1] }}"
-        opts: "-d sunit=512,swidth=512 -L {{ item.split()[1] }}"
+        dev: "{{ item.split()[2] }}"
+        opts: "-d sunit=512,swidth=512 -L {{ item.split()[1][:12] }}"
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
@@ -63,7 +63,7 @@
     - name: Mount the drives
       mount:
         path: "/srv/node/{{ item.split()[1] }}"
-        src: "LABEL={{ item.split()[1] }}"
+        src: "LABEL={{ item.split()[1][:12] }}"
         fstype: xfs
         state: mounted
         opts: "rw,noatime,nodiratime,seclabel,attr2,inode64,logbufs=8,sunit=512,swidth=512,noquota"

--- a/tasks/swift-ring-builder.yml
+++ b/tasks/swift-ring-builder.yml
@@ -56,9 +56,9 @@
           {% elif item.1.name == "object" %}
           --port {{ item.1.port | default(swift_object_port) }}
           {% endif %}
-          --device {{ item.0.disk.device }}
+          --device {{ item.0.disk.device.split('/') | last }}
           --weight {{ item.1.weight |default(0) }}
-          --meta {{ item.0.disk.device }}
+          --meta {{ item.0.disk.device if item.0.disk.device.startswith('/dev/') else '/dev/' + item.0.disk.device  }}
       with_subelements:
         - "{{ swift_rings_disks }}"
         - disk.rings


### PR DESCRIPTION
Some disks might not show up under /dev/, for example, LVM or iSCSI
devices.

This patch adds the ability to express the device using its full path,
for example `/dev/sdb` instead of just `sdb`.

The device ring still uses the last part of the device (splitting on '/
') but stores the full device path in the meta field.

When performing disk operations such as formatting and mounting, the
full path is used.