### PR TITLE
get last 12 chars for disk label

### DIFF
--- a/tasks/swift-disk-prepare.yml
+++ b/tasks/swift-disk-prepare.yml
@@ -53,7 +53,7 @@
         fstype: xfs
         force: false
         dev: "{{ item.split()[2] }}"
-        opts: "-d sunit=512,swidth=512 -L {{ item.split()[1][:12] }}"
+        opts: "-d sunit=512,swidth=512 -L {{ item.split()[1][-12:] }}"
       become: true
       with_items: "{{ swift_disks_list }}"
       when:
@@ -63,7 +63,7 @@
     - name: Mount the drives
       mount:
         path: "/srv/node/{{ item.split()[1] }}"
-        src: "LABEL={{ item.split()[1][:12] }}"
+        src: "LABEL={{ item.split()[1][-12:] }}"
         fstype: xfs
         state: mounted
         opts: "rw,noatime,nodiratime,seclabel,attr2,inode64,logbufs=8,sunit=512,swidth=512,noquota"


### PR DESCRIPTION
XFS only supports a maximum of 12 chars for a label. This is currently
derived from the last part of the disk path, e.g. `sdb` for `/dev/sdb`.
However, for disks which are more complex, such as mpath, the device may
be too long.

In the patch that added support for complex device names, the label was
set by getting the first 12 chars. However, it's probably better to get
the last 12 chars as that's where integers are more likely to be and so
we're less likely to have conflicts. For labels less than 12 chars, this
makes no difference.

Ultimately, the label should be set to the id of the disk in the Swift
rings, but that requires the library to be finished and so until then,
this patch should help.