### PR TITLE
flush handlers after playbook sections complete

### DIFF
--- a/tasks/common-logging.yml
+++ b/tasks/common-logging.yml
@@ -25,3 +25,5 @@
   tags:
     - logging
     - prep
+
+- meta: flush_handlers

--- a/tasks/swift-account-config.yml
+++ b/tasks/swift-account-config.yml
@@ -15,3 +15,5 @@
     - account
     - config
     - services
+
+- meta: flush_handlers

--- a/tasks/swift-container-config.yml
+++ b/tasks/swift-container-config.yml
@@ -15,3 +15,5 @@
     - config
     - container
     - services
+
+- meta: flush_handlers

--- a/tasks/swift-hitch.yml
+++ b/tasks/swift-hitch.yml
@@ -46,3 +46,5 @@
     - hitch
   when:
     - "inventory_hostname in groups['swift_proxy']"
+
+- meta: flush_handlers

--- a/tasks/swift-keepalived.yml
+++ b/tasks/swift-keepalived.yml
@@ -27,3 +27,5 @@
   tags:
     - keepalived
     - services
+
+- meta: flush_handlers

--- a/tasks/swift-memcached.yml
+++ b/tasks/swift-memcached.yml
@@ -41,3 +41,5 @@
   tags:
     - prep
     - memcached
+
+- meta: flush_handlers

--- a/tasks/swift-object-config.yml
+++ b/tasks/swift-object-config.yml
@@ -32,3 +32,5 @@
     - config
     - object
     - services
+
+- meta: flush_handlers

--- a/tasks/swift-proxy-config.yml
+++ b/tasks/swift-proxy-config.yml
@@ -15,3 +15,5 @@
     - config
     - proxy
     - services
+
+- meta: flush_handlers

--- a/tasks/swift-ring-distribute.yml
+++ b/tasks/swift-ring-distribute.yml
@@ -11,10 +11,6 @@
       when:
         - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
 
-      notify:
-        - "restart openstack swift proxy server"
-        - "restart openstack swift account server"
-
     - name: Push container ring to cluster
       synchronize:
         src: /etc/swift/{{ item.name }}.ring.gz
@@ -24,9 +20,6 @@
       become: true
       when:
         - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
-      notify:
-        - "restart openstack swift proxy server"
-        - "restart openstack swift container server"
 
     - name: Push object rings to cluster
       synchronize:
@@ -39,8 +32,5 @@
       become: true
       when:
         - "inventory_hostname in groups['swift_account'] or inventory_hostname in groups['swift_container'] or inventory_hostname in groups['swift_object']"
-      notify:
-        - "restart openstack swift proxy server"
-        - "restart openstack swift object server"
   tags:
     - rings

--- a/tasks/swift-rsyncd.yml
+++ b/tasks/swift-rsyncd.yml
@@ -27,3 +27,5 @@
   tags:
     - prep
     - rsyncd
+
+- meta: flush_handlers

--- a/tasks/swift-ssl.yml
+++ b/tasks/swift-ssl.yml
@@ -49,6 +49,7 @@
 - name: Trust SSL CA cert
   command:
     cmd: update-ca-trust
+  changed_when: false
   tags:
     - ssl
     - prep


### PR DESCRIPTION
If a playbook run fails, some services can become broken. This is
because while handlers are notified after certain tasks (like writing a
config file) they aren't run until the end of the play and if the
playbook fails, then the handlers aren't run.

Then next time the playbook is successfully run, the config files are not
changed and so the hanlders are not notified.

This patch simply flushes the handlers after each section of the play,
however a proper fix needs to be implemented making the configurations
themselves more robust (with blocks and rescue).

Fixes #10