### PR TITLE
install python3-libsemanage selinux dependency

### DIFF
--- a/tasks/common-selinux.yml
+++ b/tasks/common-selinux.yml
@@ -1,7 +1,9 @@
 ---
 - name: Install dependencies for SELinux module
   dnf:
-    name: python3-libselinux
+    name:
+      - python3-libselinux
+      - python3-libsemanage
     state: present
   register: dnf_selinux_result
   retries: "{{ swift_retries }}"


### PR DESCRIPTION
SELinux also needs the python3-libsemanage package on minimal CentOS 8 Stream installs.