### PR TITLE
determine device with outward IP for keepalived, vrrp firewall rule

### DIFF
--- a/tasks/common-firewall.yml
+++ b/tasks/common-firewall.yml
@@ -41,3 +41,17 @@
   tags:
     - prep
     - firewall
+
+- name: Add rich rules to firewall zone
+  firewalld:
+    rich_rule: "{{ item }}"
+    zone: "{{ swift_firewall_zone }}"
+    permanent: true
+    state: enabled
+    immediate: true
+  with_items:
+    - "rule family='ipv4' source address='{{ swift_outward_subnet }}' protocol value='vrrp' accept"
+  become: true
+  tags:
+    - prep
+    - firewall

--- a/templates/keepalived_keepalived.conf.j2
+++ b/templates/keepalived_keepalived.conf.j2
@@ -26,7 +26,7 @@ vrrp_instance VI_{{ vip }} {
     state BACKUP
     priority {{ 100 - loop.index0 }}
 {% endif %}
-    interface eth0
+    interface {% for net in ansible_interfaces %}{% if hostvars[inventory_hostname]['ansible_' + net]['ipv4']['address'] | default('127.0.0.1') | ipaddr(swift_outward_ip) %}{{ net + '\n' }}{% endif %}{% endfor %}
     virtual_router_id {{ vip }}
     advert_int 1
     authentication {


### PR DESCRIPTION
The keepalived config was hard-coded to use `eth0` which meant that it did not start properly on nodes where the device had a different name.

This change updates the template to loop through all network interfaces and find the one that matches the outward IP.